### PR TITLE
Fix latest syncthing returns empty event list

### DIFF
--- a/src/event-caller.js
+++ b/src/event-caller.js
@@ -41,7 +41,9 @@ export default function eventCaller(req, retries) {
       }
 
       //Update event count
-      since = eventArr[eventArr.length -1].id
+      if (eventArr.length > 0) {
+        since = eventArr[eventArr.length -1].id
+      }
 
       //Reset tries
       tries = 0


### PR DESCRIPTION
Since we get empty array eventArr[eventArr.length-1] is undefined. ".id" of is throws exception as id of undefined.
This is a fix for it.